### PR TITLE
Configure AWS CodeArtifact for Maven publishing

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,23 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3
-    
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: us-east-1
+
+    - name: Get CodeArtifact token
+      run: |
+        export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain thrivemarket --domain-owner 904233098208 --region us-east-1 --query authorizationToken --output text`
+        echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
+
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
-        server-id: github
-        settings-path: ${{ github.workspace }}
-    
+
     - name: Build with Maven
       run: mvn -B package
 
-    - name: Publish to GitHub Packages
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+    - name: Publish to AWS CodeArtifact
+      run: mvn deploy
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        CODEARTIFACT_AUTH_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ secrets.CODEARTIFACT_PUBLISHER_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Get CodeArtifact token

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ Add the following dependency to your `pom.xml`:
 </dependency>
 ```
 
-### GitHub Packages Configuration
+### AWS CodeArtifact Configuration
 
-To use this library from GitHub Packages, add the following to your `~/.m2/settings.xml`:
+To use this library from AWS CodeArtifact, add the following to your `~/.m2/settings.xml`:
 
 ```xml
 <settings>
   <servers>
     <server>
-      <id>github</id>
-      <username>${github.user}</username>
-      <password>${github.token}</password>
+      <id>codeartifact</id>
+      <username>aws</username>
+      <password>${env.CODEARTIFACT_AUTH_TOKEN}</password>
     </server>
   </servers>
 </settings>
@@ -58,11 +58,19 @@ And add the repository to your `pom.xml`:
 ```xml
 <repositories>
     <repository>
-        <id>github</id>
-        <url>https://maven.pkg.github.com/thrivemarket/java-logging</url>
+        <id>codeartifact</id>
+        <url>https://thrivemarket-904233098208.d.codeartifact.us-east-1.amazonaws.com/maven/libraries/</url>
     </repository>
 </repositories>
 ```
+
+Before building or deploying, export the CodeArtifact authorization token:
+
+```bash
+export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain thrivemarket --domain-owner 904233098208 --region us-east-1 --query authorizationToken --output text`
+```
+
+Note: The token expires in 12 hours.
 
 ## Usage
 
@@ -234,6 +242,20 @@ mvn clean install
 Run tests:
 ```bash
 mvn test
+```
+
+### Publishing to AWS CodeArtifact
+
+To publish a new version to AWS CodeArtifact:
+
+1. Export the CodeArtifact authorization token:
+```bash
+export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain thrivemarket --domain-owner 904233098208 --region us-east-1 --query authorizationToken --output text`
+```
+
+2. Deploy to CodeArtifact:
+```bash
+mvn deploy
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,9 @@
     
     <distributionManagement>
         <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/thrivemarket/java-logging</url>
+            <id>codeartifact</id>
+            <name>AWS CodeArtifact</name>
+            <url>https://thrivemarket-904233098208.d.codeartifact.us-east-1.amazonaws.com/maven/libraries/</url>
         </repository>
     </distributionManagement>
     

--- a/settings.xml.example
+++ b/settings.xml.example
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>codeartifact</id>
+            <username>aws</username>
+            <password>${env.CODEARTIFACT_AUTH_TOKEN}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
## Summary
Configures the project to publish to AWS CodeArtifact instead of GitHub Packages.

## Changes
- Updated `distributionManagement` in pom.xml to use AWS CodeArtifact repository URL
- Added `settings.xml.example` demonstrating authentication configuration
- Updated README.md with:
  - CodeArtifact setup instructions for consumers
  - Publishing instructions for maintainers
  - Authentication token generation commands

## Publishing Instructions
To publish to CodeArtifact:

1. Export the authorization token:
```bash
export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain thrivemarket --domain-owner 904233098208 --region us-east-1 --query authorizationToken --output text`
```

2. Deploy:
```bash
mvn deploy
```

Note: Tokens expire in 12 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)