### PR TITLE
Add Qlty code coverage integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Upload coverage to Qlty
       env:
         QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-      run: ~/.qlty/bin/qlty coverage publish target/site/jacoco/jacoco.xml
+      run: ~/.qlty/bin/qlty coverage publish target/site/jacoco/jacoco.xml --add-prefix src/main/java/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Upload coverage to Qlty
       env:
         QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-      run: qlty coverage publish target/site/jacoco/jacoco.xml
+      run: ~/.qlty/bin/qlty coverage publish target/site/jacoco/jacoco.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3
@@ -22,10 +25,9 @@ jobs:
     - name: Run tests with coverage
       run: mvn -B test
 
-    - name: Install Qlty CLI
-      run: curl https://qlty.sh | sh
-
     - name: Upload coverage to Qlty
-      env:
-        QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-      run: ~/.qlty/bin/qlty coverage publish target/site/jacoco/jacoco.xml --add-prefix src/main/java/
+      uses: qltysh/qlty-action/coverage@v2
+      with:
+        oidc: true
+        files: target/site/jacoco/jacoco.xml
+        add-prefix: src/main/java/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Run tests with coverage
+      run: mvn -B test
+
+    - name: Install Qlty CLI
+      run: curl https://qlty.sh | sh
+
+    - name: Upload coverage to Qlty
+      env:
+        QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+      run: qlty coverage publish target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
## Summary

This PR integrates Qlty code coverage into the java-logging repository:

- Added JaCoCo Maven plugin (v0.8.8) to generate XML coverage reports in `target/site/jacoco/jacoco.xml`
- Created a new `.github/workflows/test.yml` workflow that:
  - Runs on pull requests and pushes to main branch
  - Executes Maven tests with JaCoCo coverage instrumentation
  - Installs the Qlty CLI
  - Uploads coverage data to Qlty using the org-wide `QLTY_COVERAGE_TOKEN` secret

## Authentication Approach

Using token-based authentication with the existing org-wide `QLTY_COVERAGE_TOKEN` secret (no additional secrets needed).

## Test Plan

- [ ] Verify the test workflow runs successfully on this PR
- [ ] Confirm coverage data is uploaded to Qlty
- [ ] Validate that coverage reports appear in Qlty dashboard
- [ ] Check that existing tests pass and coverage is generated

Generated with [Claude Code](https://claude.com/claude-code)